### PR TITLE
Bulk Delete Unstarred User Taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,23 @@
 
 Start your party by launching a server with one of the following options:
 
+#### The super easy way
+```shell
+clojure -Sdeps '{:deps {com.github.markbastian/keg-party
+                  {:git/url "https://github.com/markbastian/keg-party"
+                  :sha     "5e35bf66a3fa761d7d4ae133c564bce55a7a9c66"}}}'
+                   -X keg-party.main/run
+```
+
+#### Other ways
+
 - `clj -X keg-party.main/run` from the cloned project
 - Build an uberjar with `clojure -X:uberjar` then run it with `java -jar keg-party.jar`
 
 By default, the server will run at `http://localhost:3333`. You can change these defaults as described in the
 configuration section below.
+
+### The initial experience
 
 When you connect to the server, you'll be directed to a login page:
 
@@ -99,6 +111,7 @@ Features:
 - [ ] Add admin profile concept so that only admins can see client tabs, for example
 - [X] Expose favorites
   - [ ] Create favorites view (or do something else with it)
+  - [X] Add "nuke all non favorites" option
 - [ ] User spaces/channels
 - [ ] Collaborative tap comments
 - [ ] Drill-down/explore individual tap data
@@ -119,7 +132,7 @@ Architecture & Tech debt:
 - [ ] Tied to the above, do some sort of event log maybe
 - [ ] With an event log we could batch notifications so we don't hammer the UI with too many taps at once
 - [ ] Refactor `migrations` into something that isn't a terrible name
-- [ ] BUG - When you go to http://localhost:3333/ in a new incognito window you get
+- [X] BUG - When you go to http://localhost:3333/ in a new incognito window you get
   - `HTTP ERROR 500 Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null`
   - Why?
   - If you go to `/login` it gets fine. It should redirect and, in fact, does later on.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,10 @@
 # Architecture
 
 - All mutations enter as commands
+- Non-persistent changes (e.g. a local user view) are regular htmx localized changes
+- Maybe
+  - If feedback/ack is required, submit command via hx-post
+  - Fire and forget will be through ws
 - All stateful objects are wrapped in records and exposed as protocols - this is clean
   - stateful: I/o, disk, db, sockets
   - NOT serializable as data

--- a/src/generic/ws_handlers.clj
+++ b/src/generic/ws_handlers.clj
@@ -12,11 +12,13 @@
                           :accept    :htmx
                           :ws        ws})))
 
-(defn on-text [{{:keys [_username session-id]} :session :as context} _ws text-message]
+(defn on-text [{{:keys [username session-id]} :session :as context} _ws text-message]
   (let [json    (u/read-json text-message)
         command (-> json
                     (update :command keyword)
-                    (assoc :client-id session-id))]
+                    (assoc
+                     :username username
+                     :client-id session-id))]
     (log/debugf "client-id: %s command: %s" session-id command)
     (cmd/dispatch-command context command)))
 

--- a/src/keg_party/commands.clj
+++ b/src/keg_party/commands.clj
@@ -47,3 +47,9 @@
   (events/delete-favorite-tap-message!
    context
    {:username username :tap-id message-id}))
+
+(defmethod cmd/dispatch-command :delete-unstarred-taps
+  [{:keys [ds] :as context} {:keys [command username message-id]}]
+  (log/infof "Dispatching command %s for %s" command message-id)
+  (let [ids (migrations/delete-unstarred-taps! ds username)]
+    (events/bulk-delete-tap-messages! context (map :id ids))))

--- a/src/keg_party/events.clj
+++ b/src/keg_party/events.clj
@@ -33,6 +33,14 @@
                         :hx-swap-oob "delete"}])]
     (client-api/broadcast! clients html)))
 
+(defn bulk-delete-tap-messages! [{:keys [client-manager]} message-ids]
+  (let [clients (client-api/clients client-manager)
+        html    (html
+                 (for [message-id message-ids]
+                   [:div {:id          (format "code-block-%s" message-id)
+                          :hx-swap-oob "delete"}]))]
+    (client-api/broadcast! clients html)))
+
 (defn create-favorite-tap-message! [{:keys [client-manager]}
                                     {:keys [username tap-id]}]
   (let [clients (client-api/clients client-manager username)

--- a/src/keg_party/pages.clj
+++ b/src/keg_party/pages.clj
@@ -66,7 +66,7 @@
           [:button.btn.btn-dark.btn-sm
            {:onclick (format
                       "navigator.clipboard.writeText(atob('%s'));
-                       showToast('%s')"
+                        showToast('%s')"
                       (u/base64-encode message)
                       copy-toast-id)}
            [:i.fa-solid.fa-copy]]
@@ -106,6 +106,11 @@
     [:ul.navbar-nav.me-auto.mb-2.mb-lg-0
      [:li.nav-item
       [:a.nav-link.active {:href "/clients"} "Clients"]]
+     [:li.nav-item
+      [:a.nav-link.active
+       {:href "#"
+        :ws-send "true"
+        :hx-vals (u/to-json-str {:command :delete-unstarred-taps})} "Delete Unstarred"]]
      [:li.nav-item
       [:a.nav-link {:href "/logout"}
        (format "Logout %s" (:username session))]]]]])

--- a/src/keg_party/system.clj
+++ b/src/keg_party/system.clj
@@ -46,24 +46,4 @@
   (start!)
   (stop!)
   (restart!)
-  (system)
-
-  (require '[keg-party.clients.rest-client])
-  (keg-party.clients.rest-client/tap-in!)
-
-  ;; A code form
-  (tap>
-   '(defn start!
-      ([config]
-       (alter-var-root #'*system* (fn [s] (if-not s (ig/init config) s))))
-      ([] (start! config))))
-
-  ;; A matrix
-  (tap> (vec (repeatedly 10 #(vec (repeatedly 10 (fn [] (rand-int 10)))))))
-
-  ;; A tall tap
-  (tap> (into {} (for [i (range 100)]
-                   [(keyword (str "key-" i)) i])))
-
-  ;; A wide tap
-  (tap> (apply str (repeat 1000 "X"))))
+  (system))

--- a/test/keg_party/tap_generator.clj
+++ b/test/keg_party/tap_generator.clj
@@ -18,4 +18,21 @@
 
 (comment
   (doseq [a (mg/sample address)]
-    (tap> a)))
+    (tap> a))
+
+  ;; A code form
+  (tap>
+   '(defn start!
+      ([config]
+       (alter-var-root #'*system* (fn [s] (if-not s (ig/init config) s))))
+      ([] (start! config))))
+
+  ;; A matrix
+  (tap> (vec (repeatedly 10 #(vec (repeatedly 10 (fn [] (rand-int 10)))))))
+
+  ;; A tall tap
+  (tap> (into {} (for [i (range 100)]
+                   [(keyword (str "key-" i)) i])))
+
+  ;; A wide tap
+  (tap> (apply str (repeat 1000 "X"))))


### PR DESCRIPTION
Added menu option to delete any unstarred taps owned by the current user. This is done by generating a command via ws, processing the command, then generating a block htmx delete for the target taps.