### PR TITLE
Fix resource paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Start your party by launching a server with one of the following options:
 ```shell
 clojure -Sdeps '{:deps {com.github.markbastian/keg-party
                   {:git/url "https://github.com/markbastian/keg-party"
-                  :sha     "39a6413a43259ab8fa3350a7c2eac7c8b44152b8"}}}' \
+                  :sha     "36f920537a94bc81d9c3a5dd5f1d66ccb49fd206"}}}' \
                    -X keg-party.main/run
 ```
 
@@ -151,7 +151,7 @@ Bugs:
   - Probably just a full swap since this is so destructive (Yep)
     - Instead of nuking the unstarred on the FE just reload with 10 starred
 - [ ] Drilling down to non-parseable entities blows up
-- [ ] Figure out how to serve resources with clj -X execution
+- [X] Figure out how to serve resources with clj -X execution
 
 Client QoL:
 - [ ] Add args for deps so we can easily launch with -X args

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Features:
 - [ ] Collaborative tap comments
 - [ ] Drill-down/explore individual tap data
 - [ ] When you sign up, show a page with a hint (copyable code?) for how to setup your tap target
+- [ ] Push client code to clojars
+  - Maybe make a separate repo
+- [ ] Can I inject the client via a [java agent](https://dgopstein.github.io/articles/clojure-javaagent/)?
 
 Architecture & Tech debt:
 - [X] Create protocols for db ops to hide implementation (e.g. users and taps)
@@ -148,6 +151,7 @@ Bugs:
   - Probably just a full swap since this is so destructive (Yep)
     - Instead of nuking the unstarred on the FE just reload with 10 starred
 - [ ] Drilling down to non-parseable entities blows up
+- [ ] Figure out how to serve resources with clj -X execution
 
 Client QoL:
 - [ ] Add args for deps so we can easily launch with -X args

--- a/src/keg_party/web.clj
+++ b/src/keg_party/web.clj
@@ -158,7 +158,7 @@
                                 request username id tap (= idx tap-count)))
                              recent-taps)))))}]
    gweb/route
-   ["/public/*" (ring/create-file-handler {:root "resources"})]])
+   ["/public/*" (ring/create-resource-handler {:root "resources"})]])
 
 (def handler
   (ring/ring-handler


### PR DESCRIPTION
When running clojure -Sdeps ... from an empty directory resources weren't being served. This was because `create-file-handler` was being used instead of `create-resouce-handler`.