### PR TITLE
Convert from depstar to tools.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ clojure -Sdeps '{:deps {com.github.markbastian/keg-party
 #### Other ways
 
 - `clj -X keg-party.main/run` from the cloned project
-- Build an uberjar with `clojure -X:uberjar` then run it with `java -jar keg-party.jar`
+- Build an uberjar with `clj -T:build uber` then run it with `java -jar target/keg-party-${LATEST_VERSION}-standalone.jar`
 
 By default, the server will run at `http://localhost:3333`. You can change these defaults as described in the
 configuration section below.

--- a/build/build.clj
+++ b/build/build.clj
@@ -1,0 +1,49 @@
+(ns build
+  "See https://clojure.org/guides/tools_build for reference."
+  (:require
+   [clojure.tools.build.api :as b])
+  (:refer-clojure :exclude [compile]))
+
+(def lib 'org.markbastian/keg-party)
+(def version (format "0.0.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+(def uberjar-file (format "target/%s-%s-standalone.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn compile [_]
+  (b/javac {:src-dirs ["java"]
+            :class-dir class-dir
+            :basis basis
+            :javac-opts ["--release" "11"]}))
+
+(defn jar
+  "Build a jarfile. Invoke with `clj -T:build jar`"
+  [_]
+  (compile nil)
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn uber
+  "Build an executable uberjar. Invoke with `clj -T:build uber`"
+  [_]
+  (clean nil)
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/compile-clj {:basis basis
+                  :src-dirs ["src"]
+                  :class-dir class-dir})
+  (b/uber {:class-dir class-dir
+           :uber-file uberjar-file
+           :basis basis
+           :main 'keg-party.main}))

--- a/deps.edn
+++ b/deps.edn
@@ -30,25 +30,12 @@
                 {:git/url "https://github.com/cognitect-labs/test-runner"
                  :sha     "2d69f33d7980c3353b246c28f72ffeafbd9f2fab"}}
    :exec-fn    cognitect.test-runner.api/test}
-  :jar     {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
-            :exec-fn      hf.depstar/jar
-            :exec-args    {:jar "keg-party.jar" :sync-pom true}}
-  :uberjar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
-            :exec-fn      hf.depstar/uberjar
-            :exec-args    {:aot        true
-                           :jar        "keg-party.jar"
-                           :main-class "keg-party.main"
-                           :sync-pom   true}}
   :install {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
             :exec-fn      deps-deploy.deps-deploy/deploy
             :exec-args    {:installer :local :artifact "keg-party.jar"}}
   :deploy  {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
             :exec-fn      deps-deploy.deps-deploy/deploy
             :exec-args    {:installer :remote :artifact "keg-party.jar"}}
-  :tap-in  {;:exec-fn   keg-party.clients.rest-client/foo
-            :main-opts ["-m" "keg-party.clients.rest-client"]}
-  ;; Not ready yet
-  ;:tap-in  {:exec-fn   keg-party.clients.rest-client/tap-launcher
-  ;          :exec-args {:host "http://localhost"
-  ;                      :port 3000}}
-  }}
+  :build {:paths ["build"]
+          :deps {io.github.clojure/tools.build {:git/tag "v0.9.5" :git/sha "24f2894"}}
+          :ns-default build}}}


### PR DESCRIPTION
Converted from depstar to tools.build. Code is in build, but we might want to adopt a more maven-esque pattern of src/client, src/server, src/build, etc.