### PR TITLE
Adding logic to delete empty channels

### DIFF
--- a/src/keg_party/commands.clj
+++ b/src/keg_party/commands.clj
@@ -79,3 +79,9 @@
             (events/bulk-reset-tap-messages! context {:username username}))
           (log/warnf "Unable to create channel %s" channel-name)))
       (log/infof "User %s is already in channel %s" username channel-name))))
+
+(defmethod cmd/dispatch-command :delete-channel
+  [{:keys [repo] :as context} {:keys [command channel-name]}]
+  (log/infof "Dispatching command %s for channel %s" command channel-name)
+  (when (repository/delete-channel! repo {:name channel-name})
+    (events/update-channels-list-message! context nil)))

--- a/src/keg_party/repository.clj
+++ b/src/keg_party/repository.clj
@@ -27,4 +27,5 @@
 (defprotocol IChannelActions
   (set-user-channel! [_ user channel])
   (get-user-channel [_ user])
-  (get-channel-users [_ channel]))
+  (get-channel-users [_ channel])
+  (delete-channel! [_ channel]))


### PR DESCRIPTION
This PR adds two icons next to each channel name -- The first allows you to quickly enter a channel and the second allows you to delete a channel.

In order to delete the channel, the channel must have no users in it.

Fixes #33 